### PR TITLE
fix: remove prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "react-native start",
     "test": "jest --passWithNoTests",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "prepare": "husky install",
     "postinstall": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
All versions of `yarn` support `postinstall` no need for `prepare` to maintain backward compatibility.